### PR TITLE
Change that created in "us-west-2" to be created in env "AWS_REGION"

### DIFF
--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -1,6 +1,4 @@
-provider "aws" {
-  region = local.region
-}
+provider "aws" {}
 
 provider "kubernetes" {
   host                   = module.eks_blueprints.eks_cluster_endpoint
@@ -28,13 +26,14 @@ provider "helm" {
   }
 }
 
+data "aws_region" "current" {}
 data "aws_availability_zones" "available" {}
 
 locals {
   name = basename(path.cwd)
   # var.cluster_name is for Terratest
   cluster_name = coalesce(var.cluster_name, local.name)
-  region       = "us-west-2"
+  region       = data.aws_region.current.name
 
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)


### PR DESCRIPTION
### What does this PR do?

Add data.aws_region.current.
Change locals.region value from "us-west-2" to data.aws_region.current.name.
As README.md.


### Motivation

README say
export AWS_REGION=<ENTER YOUR REGION>   # Select your own region
terraform plan
but doesn't effect.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
-> I did
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
-> Update example itself.
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
-> To snyc for examples docs
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?
-> yes

### Additional Notes

aws --version
aws-cli/2.7.10 Python/3.9.11 Linux/5.10.102.1-microsoft-standard-WSL2 exe/x86_64.ubuntu.20 prompt/off

kubectl version
Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.1", GitCommit:"632ed300f2c34f6d6d15ca4cef3d3c7073412212", GitTreeState:"clean", BuildDate:"2021-08-19T15:45:37Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}

terraform version
Terraform v1.2.0
